### PR TITLE
Shift-scroll scrolls the grid sideways.

### DIFF
--- a/pyspread/src/gui/_grid.py
+++ b/pyspread/src/gui/_grid.py
@@ -1152,8 +1152,11 @@ class GridEventHandlers(GridActionEventMixin):
         else:
             x, y = self.grid.GetViewStart()
             direction = 1 if event.GetWheelRotation() < 0 else -1
-            self.grid.Scroll(x, y + direction)
-            event.Skip()
+            if event.ShiftDown():
+              # Scroll sideways if shift is pressed.
+              self.grid.Scroll(x + direction, y)
+            else:
+              self.grid.Scroll(x, y + direction)
 
     # Find events
 

--- a/pyspread/src/gui/_grid.py
+++ b/pyspread/src/gui/_grid.py
@@ -1153,10 +1153,10 @@ class GridEventHandlers(GridActionEventMixin):
             x, y = self.grid.GetViewStart()
             direction = 1 if event.GetWheelRotation() < 0 else -1
             if event.ShiftDown():
-              # Scroll sideways if shift is pressed.
-              self.grid.Scroll(x + direction, y)
+                # Scroll sideways if shift is pressed.
+                self.grid.Scroll(x + direction, y)
             else:
-              self.grid.Scroll(x, y + direction)
+                self.grid.Scroll(x, y + direction)
 
     # Find events
 


### PR DESCRIPTION
I think this is a nice feature to have.

I believe the `event.Skip()` in the current version is in error, it sends two scroll events to the grid.